### PR TITLE
Add delete-comments endpoint, basic user auth

### DIFF
--- a/server/src/main/java/com/google/sps/data/UserBuilder.java
+++ b/server/src/main/java/com/google/sps/data/UserBuilder.java
@@ -1,0 +1,55 @@
+package com.google.sps.data;
+
+
+/**
+* Fluent Builder class for the User database model
+*/
+public final class UserBuilder {
+
+    private String email;
+    private long id;
+
+    /**
+    * Directly adds all parameters to the builder.
+    * @param id the id of the user.
+    * @param email the email of the user.
+    */
+    public UserBuilder (long id, String email) {
+        this.email = email;
+        this.id = id;
+    }
+
+    /**
+    * Empty constructor for use of Fluent interface.
+    */
+    public UserBuilder() {
+    }
+
+    /**
+    * Sets the email of the builder.
+    * @param email the email of the user.
+    */
+    public UserBuilder setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+
+    /**
+    * Sets the email of the builder.
+    * @param id the id of the user.
+    */
+    public UserBuilder setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+
+    /**
+    * Builds the User instance.
+    * @returns a new User instance with the properties set.
+    */
+    public UserModel build () {
+        return new UserModel(id, email);
+    }
+}

--- a/server/src/main/java/com/google/sps/data/UserModel.java
+++ b/server/src/main/java/com/google/sps/data/UserModel.java
@@ -1,0 +1,28 @@
+package com.google.sps.data;
+
+
+/**
+* Database model for the User type 
+*/
+public final class UserModel {
+
+    private final String email;
+    private final long id;
+
+    /**
+    * Full constructor of all properties of the user.
+    * @param id the id of the user.
+    * @param email the email of the user.
+    */
+    public UserModel (long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+    /**
+    * @return the email of the user.
+    */
+    public String getEmail() {
+        return email;
+    }
+}

--- a/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -56,8 +56,6 @@ public class CommentsServlet extends HttpServlet {
 
         for (Entity entity : results.asIterable()) {
 
-            System.out.println(gson.toJson(entity))
-
             if (queryCount == 0)
                 break;
                 

--- a/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -48,7 +48,14 @@ public class CommentsServlet extends HttpServlet {
 
         LinkedList<Comment> comments = new LinkedList<>();
 
+        // check if # of comments are set
+        int queryCount = Integer.parseInt(getParameter(request, "query-count", "-1"));
+
         for (Entity entity : results.asIterable()) {
+
+            if (queryCount == 0)
+                break;
+                
             Comment newComment = new CommentBuilder()
                 .setId(entity.getKey().getId())
                 .setAuthor((String) entity.getProperty("author"))
@@ -56,6 +63,9 @@ public class CommentsServlet extends HttpServlet {
                 .build();
             
             comments.add(newComment);
+
+            if (queryCount > 0)
+                queryCount--;
         }
 
         response.setContentType("application/json");

--- a/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -20,6 +20,9 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.sps.data.Comment;
 import com.google.sps.data.CommentBuilder;
 import java.io.IOException;
@@ -53,6 +56,8 @@ public class CommentsServlet extends HttpServlet {
 
         for (Entity entity : results.asIterable()) {
 
+            System.out.println(gson.toJson(entity))
+
             if (queryCount == 0)
                 break;
                 
@@ -85,6 +90,22 @@ public class CommentsServlet extends HttpServlet {
         datastore.put(commentEntity);
 
         response.getWriter().println(gson.toJson(commentEntity));
+    }
+
+    @Override
+    public void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        String commentId = getParameter(request, "comment-id", "");
+
+        Filter keyFilter = new FilterPredicate("id", FilterOperator.EQUAL, commentId); 
+
+        Entity comment = datastore.prepare(new Query("Comment").setFilter(keyFilter)).asSingleEntity();
+
+        if (comment != null)
+            datastore.delete(comment.getKey());
+
+        response.setStatus(200);
+        response.getWriter().println("Success");
     }
 
     /**

--- a/server/src/main/java/com/google/sps/servlets/DeleteAllCommentsServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/DeleteAllCommentsServlet.java
@@ -30,16 +30,13 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Optional;
 import com.google.gson.Gson;
 
 /** 
 * Servlet that handles the  "/comments" endpoint 
-* @deprecated not finished yet
 */
-@WebServlet("/comment/delete")
-@Deprecated
-public class DeleteCommentServlet extends HttpServlet {
+@WebServlet("/comment/delete-all")
+public class DeleteAllCommentsServlet extends HttpServlet {
 
     private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     private Gson gson = new Gson();
@@ -47,54 +44,13 @@ public class DeleteCommentServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        String commentId = getParameter(request, "comment-id", "");
+        PreparedQuery results = datastore.prepare(new Query("Comment"));
 
-        Filter keyFilter = new FilterPredicate("id", FilterOperator.EQUAL, commentId); 
-
-        Entity comment = datastore.prepare(new Query("Comment").setFilter(keyFilter)).asSingleEntity();
-
-        System.out.println(comment);
-
-        if (comment != null)
-            datastore.delete(comment.getKey());
+        for (Entity entity : results.asIterable()) {
+            datastore.delete(entity.getKey());
+        }
 
         response.setStatus(200);
         response.getWriter().println("Success");
-    }
-
-    @Override 
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        
-        Query query = new Query("Comment");
-        PreparedQuery results = datastore.prepare(query);
-
-        for (Entity entity : results.asIterable()) {
-
-            long id = entity.getKey().getId();
-
-            getQueryById(id);
-
-
-        }
-
-    }
-
-    private void getQueryById (long id) {
-        Filter keyFilter = new FilterPredicate("key.id", FilterOperator.EQUAL, id); 
-
-        PreparedQuery comment = datastore.prepare(new Query("Comment").setFilter(keyFilter));
-
-        for (Entity entity:comment.asIterable()) {
-            System.out.println(gson.toJson(entity));
-        }
-
-    }
-
-    /**
-    * @return the request parameter, or the default value if the parameter
-    *         was not specified by the client
-    */
-    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-        return Optional.ofNullable(request.getParameter(name)).orElse(defaultValue);
     }
 }

--- a/server/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.sps.data.Comment;
+import com.google.sps.data.CommentBuilder;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import com.google.gson.Gson;
+
+/** 
+* Servlet that handles the  "/comments" endpoint 
+*/
+@WebServlet("/comment/delete")
+public class DeleteCommentServlet extends HttpServlet {
+
+    private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private Gson gson = new Gson();
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        String commentId = getParameter(request, "comment-id", "");
+
+        Filter keyFilter = new FilterPredicate("id", FilterOperator.EQUAL, commentId); 
+
+        Entity comment = datastore.prepare(new Query("Comment").setFilter(keyFilter)).asSingleEntity();
+
+        System.out.println(comment);
+
+        if (comment != null)
+            datastore.delete(comment.getKey());
+
+        response.setStatus(200);
+        response.getWriter().println("Success");
+    }
+
+    @Override 
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        
+        Query query = new Query("Comment");
+        PreparedQuery results = datastore.prepare(query);
+
+        for (Entity entity : results.asIterable()) {
+
+            long id = entity.getKey().getId();
+
+            getQueryById(id);
+
+
+        }
+
+    }
+
+    private void getQueryById (long id) {
+        Filter keyFilter = new FilterPredicate("key.id", FilterOperator.EQUAL, id); 
+
+        PreparedQuery comment = datastore.prepare(new Query("Comment").setFilter(keyFilter));
+
+        for (Entity entity:comment.asIterable()) {
+            System.out.println(gson.toJson(entity));
+        }
+
+    }
+
+    /**
+    * @return the request parameter, or the default value if the parameter
+    *         was not specified by the client
+    */
+    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        return Optional.ofNullable(request.getParameter(name)).orElse(defaultValue);
+    }
+}

--- a/server/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/server/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -1,0 +1,54 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+
+import com.google.sps.data.UserModel;
+import com.google.sps.data.UserBuilder;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.gson.*;
+
+@WebServlet("/user")
+public class UserServlet extends HttpServlet {
+
+    private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private Gson gson = new Gson();
+
+    @Override 
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        JsonObject jsonResp = new JsonObject();
+        UserService userService = UserServiceFactory.getUserService();
+
+        if (userService.isUserLoggedIn()) {
+            
+            User currUser = userService.getCurrentUser();
+
+            jsonResp.addProperty("email", currUser.getEmail());
+            jsonResp.addProperty("logoutUrl", userService.createLogoutURL("/"));
+
+            response.getWriter().println(gson.toJson(jsonResp));
+        } else {
+
+            jsonResp.addProperty("loginUrl", userService.createLoginURL("/"));
+
+            response.getWriter().println(gson.toJson(jsonResp));
+        }
+    }
+
+}

--- a/server/src/main/webapp/index.html
+++ b/server/src/main/webapp/index.html
@@ -14,11 +14,19 @@
         <form action="/comments" method="POST" id="comments-form">
             <input type="text" name="comment-author" placeholder ="Author"/>
             <textarea name="comment-content" placeholder="Comment"></textarea>
+
             <button type="submit">Submit</button>
         </form>
 
         <div>
             <h3>See Comments</h3>
+
+            <h4>How many?</h4>
+            <select id="query-count">
+                <option value="-1">all</option>
+                <option value="2">2</option>
+            </select>
+
             <button onclick="addCommentsToDom()">Get Comments</button>
             <div id="server-content"></div>
         </div>

--- a/server/src/main/webapp/index.html
+++ b/server/src/main/webapp/index.html
@@ -9,6 +9,12 @@
   <body>
     <div id="content">
         
+        <div>
+            <button onclick="getUser()">Am I Logged In?</button>
+            <span id="user-content">idk...</span>
+            <button onclick="userLogin()">Log me in</button>
+            <button onclick="userLogout()">Log me out</button>
+        </div>
         <h1>Comments</h1>
 
         <form action="/comments" method="POST" id="comments-form">
@@ -28,7 +34,10 @@ teach
             </select>
 
             <button onclick="addCommentsToDom()">Get Comments</button>
+
             <div id="server-content"></div>
+
+            <button onclick="deleteAllComments()">Delete All Comments</button>
         </div>
     </div>
   </body>

--- a/server/src/main/webapp/index.html
+++ b/server/src/main/webapp/index.html
@@ -20,7 +20,7 @@
 
         <div>
             <h3>See Comments</h3>
-
+teach
             <h4>How many?</h4>
             <select id="query-count">
                 <option value="-1">all</option>

--- a/server/src/main/webapp/script.js
+++ b/server/src/main/webapp/script.js
@@ -49,11 +49,30 @@ const addCommentsToDom = () => {
         return wrapper;
     }
 
-    getServerContent("/comments")
+    // query string
+    const fetchQuery = () => {
+        let queryString = "?"
+
+        // query count
+        const queryCountElem = document.getElementById("query-count");
+        const queryCountValue = queryCountElem.options[queryCountElem.selectedIndex].value;
+
+        queryString+=`query-count=${queryCountValue}`
+
+        return getServerContent(`/comments${queryString}`)
+    }
+
+
+    fetchQuery()
         .then(parseComments)
         .then(addToDom)
 } 
 
 const addToDom = (text) => {
-    document.getElementById("server-content").appendChild(text)
+
+    const serverContent = document.getElementById("server-content")
+    
+    serverContent.innerHTML = null
+    serverContent.appendChild(text)
+
 }

--- a/server/src/main/webapp/script.js
+++ b/server/src/main/webapp/script.js
@@ -62,7 +62,6 @@ const addCommentsToDom = () => {
         return getServerContent(`/comments${queryString}`)
     }
 
-
     fetchQuery()
         .then(parseComments)
         .then(addToDom)


### PR DESCRIPTION
This'll be the last commit for this branch before I implement all this backend into my portfolio. 

Some notes:
- `DeleteCommentServlet.java` is half-finished and therefore deprecated, it was supposed to be an endpoint to delete a specific comment by ID but I didn't get to finish it in time last week. Btw, is it better to use keys or IDs when passing some identifier to the client and using it operations? It seems like the Datastore API is easier to use by just using a key. Why do both keys and IDs exist?
- The implementation of Users is really basic; no usernames, post-OAuth form, or anything fancy. Also didn't do any of the JS stuff from the tutorial as I'll be doing my own thing in my portfolio.